### PR TITLE
Multi character trigger

### DIFF
--- a/src/TributeRange.js
+++ b/src/TributeRange.js
@@ -355,14 +355,22 @@ class TributeRange {
         }
     }
 
-    lastIndexWithLeadingSpace (str, char) {
+    lastIndexWithLeadingSpace (str, trigger) {
         let reversedStr = str.split('').reverse().join('')
         let index = -1
 
         for (let cidx = 0, len = str.length; cidx < len; cidx++) {
             let firstChar = cidx === str.length - 1
             let leadingSpace = /\s/.test(reversedStr[cidx + 1])
-            let match = char === reversedStr[cidx]
+            
+            let match = true;
+            
+            for (let triggerIdx = trigger.length - 1; triggerIdx >= 0; triggerIdx--) {
+              if(trigger[triggerIdx] !== reversedStr[cidx-triggerIdx]) {
+                match = false;
+                break;
+              }
+            }
 
             if (match && (firstChar || leadingSpace)) {
                 index = str.length - 1 - cidx
@@ -465,7 +473,7 @@ class TributeRange {
         div.textContent = element.value.substring(0, position)
 
         if (element.nodeName === 'INPUT') {
-            div.textContent = div.textContent.replace(/\s/g, ' ')
+            div.textContent = div.textContent.replace(/\s/g, ' ')
         }
 
         let span = this.getDocument().createElement('span')

--- a/test/spec/test.js
+++ b/test/spec/test.js
@@ -13,4 +13,27 @@
       expect(tribute.collection[0].values).toEqual(options);
     });
   });
+  
+  describe('Multi-char trigger', function () {
+    it('lastIndexWithLeadingSpace should detect multi-char trigger correctly', () => {
+      const options = [
+        {key: 'Phil Heartman', value: 'pheartman'},
+        {key: 'Gordon Ramsey', value: 'gramsey'}
+      ];
+      const tribute = new Tribute({
+        values: options
+      });
+      const TributeRange = require('../../src/TributeRange.js');
+      var tributeRange = new TributeRange(tribute);
+      
+
+      expect(tributeRange.lastIndexWithLeadingSpace(" {{", "{{")).toEqual(1);
+      
+      expect(tributeRange.lastIndexWithLeadingSpace("{{", "{{")).toEqual(0);
+      expect(tributeRange.lastIndexWithLeadingSpace("a{{", "{{")).toEqual(-1);
+      expect(tributeRange.lastIndexWithLeadingSpace(" {", "{{")).toEqual(-1);
+    });
+  });
+  
 })();
+


### PR DESCRIPTION
This fixes your PR for multi-character triggers, which would fail where requireLeadingSpace was true. 

There's not a comprehensive test suite so I can't vouch that this doesn't break anything, but it seems to be working.